### PR TITLE
Have dependabot update github actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+---
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,13 +1,22 @@
+---
 name: Go
 
 on:
   push:
     branches: [ "main" ]
     tags:
-        - '*'
+      - '*'
   pull_request:
     branches: [ "main" ]
+    paths-ignore:
+      - '**/*.md'
+      - .github/dependabot.yml
   workflow_dispatch:
+
+concurrency:
+  # yamllint disable-line rule:line-length
+  group: ${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:


### PR DESCRIPTION
Workflow updates for github-actions. But the dependabot.yaml file shouldn't trigger builds itself, because it should have not bearing on the build itself.

Note: The workflow won't have access to action secrets when the event was triggered by dependabot, unless the secrets are explicitly added to the repo or org.