### PR TITLE
Allow alternate OpenAI API URL with --openaiurl

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Flags:
       --model string          model to be used for responses e.g., gpt-4 (default "gpt-4")
   -n, --nick string           bot's nickname on the irc server (default "soulshack")
       --openaikey string      openai api key
+      --openaiurl string      alternative base url to use instead of openai
   -p, --port int              irc server port (default 6667)
       --prompt string         initial system prompt for the ai (default "respond in a short text:")
   -s, --server string         irc server address (default "localhost")

--- a/config.go
+++ b/config.go
@@ -41,6 +41,7 @@ func init() {
 	root.PersistentFlags().String("openaikey", "", "openai api key")
 	root.PersistentFlags().Int("maxtokens", 512, "maximum number of tokens to generate")
 	root.PersistentFlags().String("model", ai.GPT4, "model to be used for responses (e.g., gpt-4)")
+	root.PersistentFlags().String("openaiurl", "", "alternative base url to use instead of openai")
 
 	// timeouts and behavior
 	root.PersistentFlags().BoolP("addressed", "a", true, "require bot be addressed by nick for response")
@@ -87,7 +88,7 @@ func initConfig() {
 
 func verifyConfig(v *vip.Viper) error {
 	for _, varName := range v.AllKeys() {
-		if varName == "admins" || varName == "saslnick" || varName == "saslpass" {
+		if varName == "admins" || varName == "openaiurl" || varName == "saslnick" || varName == "saslpass" {
 			continue
 		}
 		value := v.GetString(varName)

--- a/soulshack.go
+++ b/soulshack.go
@@ -45,7 +45,14 @@ var root = &cobra.Command{
 
 func run(r *cobra.Command, _ []string) {
 
-	aiClient := ai.NewClient(vip.GetString("openaikey"))
+	aiConfig := ai.DefaultConfig(vip.GetString("openaikey"))
+
+	if vip.GetString("openaiurl") != "" {
+		log.Println("using alternate OpenAI API URL:", vip.GetString("openaiurl"))
+		aiConfig.BaseURL = vip.GetString("openaiurl")
+	}
+
+	aiClient := ai.NewClientWithConfig(aiConfig)
 
 	if err := verifyConfig(vip.GetViper()); err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
This can be used for using other LLM engines that support an OpenAI-compatible API, like oobabooga's text generation web UI or KoboldCpp.